### PR TITLE
Update onepass.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTParser"
 uuid = "32681960-a1b1-40db-9bff-a1ca817385d1"
 authors = ["Jean-Baptiste Caillau <jean-baptiste.caillau@univ-cotedazur.fr>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 CTBase = "54762871-cc72-4466-b8e8-f6c8b58076cd"

--- a/src/onepass.jl
+++ b/src/onepass.jl
@@ -795,7 +795,7 @@ function p_lagrange_exa!(p, p_ocp, e, type)
     ej = subs(ej, p.t, :($(p.t0) + $j * $(p.dt)))
     sg = (type == :min) ? 1 : (-1)
     code = quote 
-        if scheme == :trapezoidal
+        if scheme ∈ (:trapeze, :trapezoidal)
             ExaModels.objective($p_ocp, $sg * $(p.dt) * $ej / 2 for $j ∈ (0, grid_size))
             ExaModels.objective($p_ocp, $sg * $(p.dt) * $ej for $j ∈ 1:(grid_size - 1))
         elseif scheme == :euler


### PR DESCRIPTION
added alias `:trapeze` for `:trapezoidal` scheme (consistent with CTDirect kwargs), was missing in `p_lagrange_exa`