### PR TITLE
scalarised constraint bounds 

### DIFF
--- a/test/test_onepass_exa_bis.jl
+++ b/test/test_onepass_exa_bis.jl
@@ -1,4 +1,5 @@
 # test_onepass_exa_bis
+# todo: merge with test_onepass_exa
 
 function test_onepass_exa_bis()
     @testset "p_dynamics_exa! errors" begin


### PR DESCRIPTION
updated to scalar bounds for default (`+/- Inf`) constraints for exa in one_pass.jl 