### PR TITLE
Refactor CI workflow for test jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,17 +11,12 @@ jobs:
   # Job for the GitHub hosted runners (ubuntu, windows, macos)
   test-github:
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
-    with:
-      versions: '["1.10", "1.11", "1.12"]'
-      runs_on: '["ubuntu-latest", "windows-latest"]'
-      archs: '["x64"]'
-      runner_type: 'github'
 
   # Job for the self-hosted runner moonshot (GPU/CUDA)
   test-moonshot:
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       versions: '["1"]'
-      runs_on: '[["self-hosted", "Linux", "gpu", "cuda", "cuda12"]]'
+      runs_on: '["moonshot"]'
       archs: '["x64"]'
       runner_type: 'self-hosted'


### PR DESCRIPTION
Updated the CI workflow to simplify the test-github job and modify the test-moonshot job's runner type.