### PR TITLE
Align CI with the control-toolbox Handbook (+ split CI by runner)

### DIFF
--- a/.github/workflows/AddToProject.yml
+++ b/.github/workflows/AddToProject.yml
@@ -1,0 +1,13 @@
+name: Add to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  call:
+    uses: control-toolbox/CTActions/.github/workflows/add-to-project.yml@main
+    secrets:
+      project_token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -5,13 +5,22 @@ name: Breakage
 # no access to secrets
 on:
   pull_request:
+    types: [labeled, synchronize, reopened]
 
 jobs:
   call:
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'run breakage') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run breakage'))
     strategy:
       fail-fast: false
       matrix:
-        pkgname: [OptimalControl]
+        pkgname: [CTDirect, OptimalControl]
         pkgversion: [latest, stable]
         include:
           - pkgpath: control-toolbox

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,8 @@ on:
     types: [labeled, synchronize, reopened]
 
 jobs:
-  call:
+  # Job for the GitHub hosted runners (ubuntu, macos, windows)
+  test-github-runner:
     # A 'labeled' event fires once per label added, and re-evaluates against the PR's
     # *current* full label set — so adding several labels in a row would otherwise
     # re-run this job on every subsequent label add. Only react to 'labeled' when it's
@@ -17,12 +18,28 @@ jobs:
     # checking the current label set as before.
     if: >
       github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run ci') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci'))
+      (github.event.action == 'labeled' && github.event.label.name == 'github-runner') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'github-runner'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       runs_on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
       runner_type: 'github'
+      use_ct_registry: true
+    secrets:
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+
+  # Job for the self-hosted runner kkt (GPU/CUDA)
+  test-kkt-runner:
+    # See the comment on test-github-runner above.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'kkt-runner') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'kkt-runner'))
+    uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
+    with:
+      versions: '["1"]'
+      runs_on: '[["kkt"]]'
+      runner_type: 'self-hosted'
       use_ct_registry: true
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,23 +6,23 @@ on:
       - main
     tags: '*'
   pull_request:
-    
+    types: [labeled, synchronize, reopened]
+
 jobs:
-  # Job for the GitHub hosted runners (ubuntu, windows, macos)
-  test-github:
+  call:
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
-      runs_on: '["ubuntu-latest", "macos-latest"]'
+      runs_on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
       runner_type: 'github'
       use_ct_registry: true
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}
-
-# Job for the self-hosted runner moonshot (GPU/CUDA)
-#   test-moonshot:
-#     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
-#     with:
-#       versions: '["1"]'
-#       runs_on: '["moonshot"]'
-#       archs: '["x64"]'
-#       runner_type: 'self-hosted'

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -1,5 +1,5 @@
 # [.github/workflows/coverage.yml]
-name: coverage
+name: Coverage
 on:
   push:
     branches:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,12 +1,25 @@
 name: Documentation
+
 on:
   push:
     branches:
       - main
-    tags: '*'
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'   # v0.8.7 yes, v0.8.7-beta no
   pull_request:
+    types: [labeled, synchronize, reopened]
+
 jobs:
   call:
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run documentation') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run documentation'))
     uses: control-toolbox/CTActions/.github/workflows/documentation.yml@main
     with:
       use_ct_registry: true


### PR DESCRIPTION
Applies the workflow rules from [`Handbook/WORKFLOWS.md`](https://github.com/control-toolbox/Handbook/blob/main/WORKFLOWS.md).

## Why

`CI.yml`, `Documentation.yml` and `Breakage.yml` fired on **every event of every PR** with no gate — exactly the waste §2 exists to prevent. §4's distribution table also lists CTParser.jl as needing `AddToProject`, which was missing. Finally, CI is now split per runner (§3.1).

## Changes

| File | Change |
| --- | --- |
| `CI.yml` | **split into two jobs** per §3.1 (see below) |
| `Documentation.yml` | `run documentation` gate + `types:`; tags restricted to `v[0-9]+\.[0-9]+\.[0-9]+` so `-beta` tags stop deploying docs |
| `Breakage.yml` | `run breakage` gate + `types:`; **+`CTDirect`** in the matrix |
| `Coverage.yml` | `name: coverage` → `Coverage` (cosmetic) |
| `AddToProject.yml` | **new**, copied verbatim from CTBase.jl/CTModels.jl |

Untouched (already conforming): `Formatter`, `SpellCheck`, `CompatHelper`, `AutoAssign`, `TagBot`, `UpdateReadme`.

### CI split (§3.1, modelled on CTFlows.jl)

| Job | Runner | Julia | Label |
| --- | --- | --- | --- |
| `test-github-runner` | ubuntu + macos + **windows** | 1.10, 1.12 | `github-runner` |
| `test-kkt-runner` | self-hosted `kkt` (GPU/CUDA) | `1` | `kkt-runner` |

§3.1's table classifies CTParser.jl as having no GPU-relevant code and keeping a single `run ci` job. **That is stale:** `test/Project.toml` depends on `CUDA`, `MadNLPGPU`, `KernelAbstractions` and `ExaModels`, and `test/runtests.jl` loads them unconditionally — so the GPU job has real work to do. Worth a Handbook correction separately.

Label names are `github-runner` / `kkt-runner` as requested, rather than the `run ci cpu` / `run ci gpu` pair used by CTFlows/CTSolvers/OptimalControl.

`opened` is deliberately excluded from the gated workflows' `types:` — per §2 it duplicates the `labeled` run when a PR is created with its label already applied. `AddToProject`/`AutoAssign` correctly keep it.

## Gate behaviour verified on this PR

- **Unlabelled:** `CI`, `Documentation`, `Breakage` → **zero** runs; ungated `SpellCheck` ran, and the new `AddToProject` fired on `opened`. ✅
- **`+github-runner`:** `test-github-runner` fanned out to 6 jobs; `test-kkt-runner` **skipped**. ✅
- **On `synchronize` with neither runner label:** both CI jobs **skipped**. ✅
- Adding a label fires exactly **one** run, never two — the `opened`-exclusion working. ✅

## Notes for the reviewer

- **`CTDirect` added to the breakage matrix** because it is a genuine downstream consumer (real `[deps]` + `[compat]`, not just a test `[extras]`). Previously only `OptimalControl` was listed.
- **`windows-latest` is new for this package** — first Windows run ever, so a failure there is a real finding, not a regression from this PR. (CTFlows.jl's Windows job is currently failing too.)
- **The `run ci` label is now inert** — the split replaced it with the two runner labels. Delete it if you don't want it lingering.
- **`kkt-runner` has not been exercised yet**; the kkt runner looked backed up (CTFlows' `test-gpu-kkt` had been queued ~40 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)